### PR TITLE
fix: 修复unix环境下载文件夹权限问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Editor directories and files
 .idea
+.DS_Store
+
+# build output dir
+/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all
+all: prepare
+
+.PHONY: prepare
+prepare:
+	@go mod download
+	@go mod tidy
+
+.PHONY: build
+build:  ## Build executable binary file
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/linux-amd64/music-get main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/linux-arm64/music-get main.go
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o bin/darwin-amd64/music-get main.go
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o bin/darwin-arm64/music-get main.go
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/windows-amd64/music-get.exe main.go
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o bin/windows-arm64/music-get.exe main.go
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/winterssy/music-get
 
+go 1.19
+
 require (
 	github.com/bogem/id3v2 v1.1.1
+	gopkg.in/cheggaaa/pb.v1 v1.0.28
+)
+
+require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	golang.org/x/sys v0.0.0-20190529085034-854af27f14a7 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	gopkg.in/cheggaaa/pb.v1 v1.0.28
 )

--- a/utils/path.go
+++ b/utils/path.go
@@ -20,7 +20,7 @@ func ExistsPath(path string) (bool, error) {
 func BuildPathIfNotExist(path string) error {
 	ok, err := ExistsPath(path)
 	if !ok {
-		return os.MkdirAll(path, 0644)
+		return os.MkdirAll(path, 0744)
 	}
 	return err
 }


### PR DESCRIPTION
1. 修复unix环境下使用0644创建文件夹导致内部文件信息无法被非root用户操作的问题
2. 优化go.mod文件支持1.19
3. 添加makefile支持简化构建操作
4. 优化.gitignore文件，忽略mac环境下.DS_Store文件，忽略二进制文件存储目录